### PR TITLE
fixing logic

### DIFF
--- a/Policies/Network/deny-vms-not-in-a-specific-subnet-from-being-part-of-a-backend-pool/azurepolicy.json
+++ b/Policies/Network/deny-vms-not-in-a-specific-subnet-from-being-part-of-a-backend-pool/azurepolicy.json
@@ -9,8 +9,10 @@
                     "equals": "Microsoft.Network/networkInterfaces"
                 },
                 {
-                    "field": "Microsoft.Network/networkInterfaces/ipConfigurations[*].applicationGatewayBackendAddressPools[*]",
-                    "exists": true
+                    "count": {
+                        "field": "Microsoft.Network/networkInterfaces/ipConfigurations[*].applicationGatewayBackendAddressPools[*]"
+                    },
+                    "greater": 0
                 },
                 {
                     "field": "Microsoft.Network/networkInterfaces/ipconfigurations[*].subnet.id",

--- a/Policies/Network/deny-vms-not-in-a-specific-subnet-from-being-part-of-a-backend-pool/azurepolicy.rules.json
+++ b/Policies/Network/deny-vms-not-in-a-specific-subnet-from-being-part-of-a-backend-pool/azurepolicy.rules.json
@@ -6,8 +6,10 @@
                 "equals": "Microsoft.Network/networkInterfaces"
             },
             {
-                "field": "Microsoft.Network/networkInterfaces/ipConfigurations[*].applicationGatewayBackendAddressPools[*]",
-                "exists": true
+                "count": {
+                    "field": "Microsoft.Network/networkInterfaces/ipConfigurations[*].applicationGatewayBackendAddressPools[*]"
+                },
+                "greater": 0
             },
             {
                 "field": "Microsoft.Network/networkInterfaces/ipconfigurations[*].subnet.id",


### PR DESCRIPTION
Previous policy would prevent the creation of additional ip configurations on a NIC even when it wasn't part of a backendpool as the backendpool element would exist during the update of the ipconfig. I'm now testing to see if there actually is a config in that element and not just the existence of that element.